### PR TITLE
Issue #23: Don't overwrite eslint mozilla/recommended rules 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,11 +36,11 @@ module.exports = {
             "error",
             2
         ],
-    "no-console": [
-        "error",
-        {
-            "allow": ["error"]
-        }
-    ]        
+        "no-console": [
+            "error",
+            {
+                "allow": ["error"]
+            }
+        ]    
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,13 +36,11 @@ module.exports = {
             "error",
             2
         ],
-        "no-console": [
-            "error",
-                 {"allow":
-                        ["warn", "info", "error"]
-                 }
-        ]
-
-        
+    "no-console": [
+        "error",
+        {
+            "allow": ["error"]
+        }
+    ]        
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,22 +36,13 @@ module.exports = {
             "error",
             2
         ],
-        "linebreak-style": [
+        "no-console": [
             "error",
-            "windows"
-        ],
-        "quotes": [
-            "warn",
-            "single"
-        ],
-        "no-unused-vars": [
-            "warn",
-            "all"
-        ],
-        "no-constant-condition": [
-            "warn"
-        ],
-        "no-console": "off"
+                 {"allow":
+                        ["warn", "info", "error"]
+                 }
+        ]
+
         
     }
 };

--- a/build.js
+++ b/build.js
@@ -11,7 +11,20 @@ const includeFiles = [
   'spinner.css', 'supported_extensions.js',
 ];
 const zipName = './gecko-code-coverage.zip';
-
+var manObj;
+fs.readFile('manifest.json', 'utf8', function (err, data) {
+  if (err) throw err;
+  manObj = JSON.parse(data);
+});
+var packObj;
+fs.readFile('package.json', 'utf8', function (err, data) {
+  if (err) throw err;
+  packObj = JSON.parse(data);
+});
+if (manObj["version"] != packObj["version"]) {
+     console.error("Different versions of manifest.json and package.json");
+     return;
+}
 https.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/supported_extensions', res => {
   let data = '';
     
@@ -24,7 +37,7 @@ https.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/supported_e
         console.error(e.message);
         return;
       }
-
+    
       fs.readdir('.', (e, files) => {
         if (e) {
           console.error(e.message);

--- a/build.js
+++ b/build.js
@@ -12,16 +12,13 @@ const includeFiles = [
 ];
 const zipName = './gecko-code-coverage.zip';
 fs.readFile('manifest.json', 'utf8', function(err, data) {
-  var manObj;
   if (err) throw err;
-  manObj = JSON.parse(data);
-  var packObj;
+  let manObj = JSON.parse(data);
   fs.readFile('package.json', 'utf8', function(err, data) {
       if (err) throw err;
-      packObj = JSON.parse(data);
+      let packObj = JSON.parse(data);
       if (manObj["version"] != packObj["version"]) {
-          console.error("Different versions of manifest.json and package.json");
-          return;
+          throw "Different versions of manifest.json and package.json";
       }
   });
 });

--- a/build.js
+++ b/build.js
@@ -15,16 +15,18 @@ var manObj;
 fs.readFile('manifest.json', 'utf8', function (err, data) {
   if (err) throw err;
   manObj = JSON.parse(data);
+  var packObj;
+  fs.readFile('package.json', 'utf8', function (err, data) {
+      if (err) throw err;
+      packObj = JSON.parse(data);
+      if (manObj["version"] != packObj["version"]) {
+          console.error("Different versions of manifest.json and package.json");
+          return;
+      }
+  });
 });
-var packObj;
-fs.readFile('package.json', 'utf8', function (err, data) {
-  if (err) throw err;
-  packObj = JSON.parse(data);
-});
-if (manObj["version"] != packObj["version"]) {
-     console.error("Different versions of manifest.json and package.json");
-     return;
-}
+
+
 https.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/supported_extensions', res => {
   let data = '';
     

--- a/build.js
+++ b/build.js
@@ -11,12 +11,12 @@ const includeFiles = [
   'spinner.css', 'supported_extensions.js',
 ];
 const zipName = './gecko-code-coverage.zip';
-var manObj;
-fs.readFile('manifest.json', 'utf8', function (err, data) {
+fs.readFile('manifest.json', 'utf8', function(err, data) {
+  var manObj;
   if (err) throw err;
   manObj = JSON.parse(data);
   var packObj;
-  fs.readFile('package.json', 'utf8', function (err, data) {
+  fs.readFile('package.json', 'utf8', function(err, data) {
       if (err) throw err;
       packObj = JSON.parse(data);
       if (manObj["version"] != packObj["version"]) {
@@ -39,13 +39,13 @@ https.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/supported_e
         console.error(e.message);
         return;
       }
-    
+      
       fs.readdir('.', (e, files) => {
         if (e) {
           console.error(e.message);
           return;
         }
-
+        
         const resultFiles = files.filter(file => includeFiles.includes(file));
 
         makeZip(resultFiles);

--- a/build.js
+++ b/build.js
@@ -26,7 +26,6 @@ fs.readFile('manifest.json', 'utf8', function(err, data) {
   });
 });
 
-
 https.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/supported_extensions', res => {
   let data = '';
     
@@ -39,13 +38,13 @@ https.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/supported_e
         console.error(e.message);
         return;
       }
-      
+
       fs.readdir('.', (e, files) => {
         if (e) {
           console.error(e.message);
           return;
         }
-        
+
         const resultFiles = files.filter(file => includeFiles.includes(file));
 
         makeZip(resultFiles);


### PR DESCRIPTION
Fixes #23.

- Commit "rules updated"
- I have deleted the lines in rules(except "intend") so that default rules should be used
- I have tried to pass through ESlint for linting locally, and it was successful. 
- An issue I have encountered was the problem that according to browser recommended rules no console output should be made as it is used for debugging primarily; hence, I allowed in rules console output for errors, warnings, and info.  

Not sure, if it is right and ready to redo it if I haven't understood correctly. :)