### PR TITLE
Update URLs to point to the production instance

### DIFF
--- a/build.js
+++ b/build.js
@@ -24,7 +24,7 @@ fs.readFile('manifest.json', 'utf8', function(err, data) {
   });
 });
 
-https.get('https://uplift.shipit.staging.mozilla-releng.net/coverage/supported_extensions', res => {
+https.get('https://uplift.shipit.mozilla-releng.net/coverage/supported_extensions', res => {
   let data = '';
     
   res.on('data', chunk => data += chunk);

--- a/coverage.js
+++ b/coverage.js
@@ -5,7 +5,7 @@
 'use strict';
 
 async function fetchCoverage(rev, path) {
-  let response = await fetch(`https://uplift.shipit.staging.mozilla-releng.net/coverage/file?changeset=${rev}&path=${path}`);
+  let response = await fetch(`https://uplift.shipit.mozilla-releng.net/coverage/file?changeset=${rev}&path=${path}`);
   return await response.json();
 }
 
@@ -21,7 +21,7 @@ async function waitIdle(time) {
 async function fetchChangesetCoverage(rev) {
   let ready = false;
   do {
-    let response = await fetch(`https://uplift.shipit.staging.mozilla-releng.net/coverage/changeset_summary/${rev}`);
+    let response = await fetch(`https://uplift.shipit.mozilla-releng.net/coverage/changeset_summary/${rev}`);
 
     if (response.status == 202) {
       await wait(5000);

--- a/socorro.js
+++ b/socorro.js
@@ -69,7 +69,7 @@ if (Object.keys(fileinfo).length != 0) {
               // line is covered or uncovered
               le.element.parentNode.style.backgroundColor = covData[line] == 0 ? "tomato" : "greenyellow";
               const gitBuildChangeset = data['git_build_changeset'];
-              const codecovUrl = `https://codecov.io/gh/marco-c/gecko-dev/src/${gitBuildChangeset}/${filename}#L${line}`;
+              const codecovUrl = `https://codecov.io/gh/mozilla/gecko-dev/src/${gitBuildChangeset}/${filename}#L${line}`;
               const a = linkToCodecov.cloneNode(true);
               a.setAttribute("href", codecovUrl);
               le.element.parentNode.append(a);


### PR DESCRIPTION
Fixes #37.

It also updates the codecov.io URL to point to mozilla/gecko-dev instead of marco-c/gecko-dev.