### PR TITLE
Support phabricator pre-patch view

### DIFF
--- a/coverage.js
+++ b/coverage.js
@@ -34,6 +34,11 @@ async function fetchChangesetCoverage(rev) {
   } while (!ready);
 }
 
+async function phidToHg(phid) {
+  let response = await fetch(`https://coverage.staging.moz.tools/phabricator/base_revision_from_phid/${phid}`);
+  return await response.json();
+}
+
 async function gitToHg(gitrev) {
   let response = await fetch(`https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/git/${gitrev}`);
   if (!response.ok) {

--- a/manifest.json
+++ b/manifest.json
@@ -48,7 +48,6 @@
     {
       "matches": ["*://phabricator.services.mozilla.com/D*"],
       "js": ["supported_extensions.js", "coverage.js", "phabricator.js"],
-      "css": ["spinner.css", "phabricator.css"],
       "run_at": "document_idle"
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -44,12 +44,20 @@
       "js": ["supported_extensions.js", "coverage.js", "button.js", "hgmo.js"],
       "css": ["spinner.css", "dxr.css"],
       "run_at": "document_end"
+    },
+    {
+      "matches": ["*://phabricator.services.mozilla.com/D*"],
+      "js": ["supported_extensions.js", "coverage.js", "phabricator.js"],
+      "css": ["spinner.css", "phabricator.css"],
+      "run_at": "document_idle"
     }
   ],
   "permissions": [
     "https://coverage.moz.tools/coverage/*",
     "https://api.pub.build.mozilla.org/mapper/gecko-dev/rev/git/*",
-    "https://reviewboard-hg.mozilla.org/gecko/*"
+    "https://reviewboard-hg.mozilla.org/gecko/*",
+    "https://hg.mozilla.org/mozilla-central/json-rev/*",
+    "https://coverage.staging.moz.tools/phabricator/*"
   ],
   "homepage_url": "https://github.com/marco-c/code-coverage-addon"
 }

--- a/phabricator.css
+++ b/phabricator.css
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* TODO: style */

--- a/phabricator.css
+++ b/phabricator.css
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-/* TODO: style */

--- a/phabricator.js
+++ b/phabricator.js
@@ -58,7 +58,7 @@ async function injectButton(block) {
   } else {
     const coverage = await fetchCoverage(parentRevision, path);
     if (!coverage.hasOwnProperty('data') || coverage.hasOwnProperty('error')) {
-      button.title = 'Failed fetching Coverage Data.'
+      button.title = 'Failed fetching coverage data.'
       return;
     } else {
       data = coverage.data;

--- a/phabricator.js
+++ b/phabricator.js
@@ -35,13 +35,13 @@ function removeOverlay(block) {
 }
 
 async function injectButton(block) {
-  let path = block.querySelector('h1.differential-file-icon-header').textContent;
+  const path = block.querySelector('h1.differential-file-icon-header').textContent;
   if (!isCoverageSupported(path)) {
     return;
   }
 
-  let buttonDiv = block.querySelector('div.differential-changeset-buttons');
-  let button = document.createElement('button');
+  const buttonDiv = block.querySelector('div.differential-changeset-buttons');
+  const button = document.createElement('button');
   button.type = 'button';
   button.textContent = 'Code Coverage';
   button.disabled = true;
@@ -50,7 +50,7 @@ async function injectButton(block) {
   button.style['cursor'] = 'not-allowed';
   buttonDiv.append(button);
 
-  let parentRevision = await parentRevisionPromise;
+  const parentRevision = await parentRevisionPromise;
   let data;
   if (!parentRevision) {
     button.title = 'Error fetching parent revision.';
@@ -85,15 +85,15 @@ async function injectButton(block) {
 
 async function fetchParentRevision() {
   const revisionPHIDpattern = RegExp('/(PHID-DREV-[^/]*)/');
-  let href = document.querySelector('a.policy-link[data-sigil=workflow]').getAttribute('href');
-  let diffIdMatch = href.match(revisionPHIDpattern);
+  const href = document.querySelector('a.policy-link[data-sigil=workflow]').getAttribute('href');
+  const diffIdMatch = href.match(revisionPHIDpattern);
   if (!diffIdMatch) {
     console.error('diff id not found!');
     return null;
   }
-  let phid = diffIdMatch[1];
+  const phid = diffIdMatch[1];
 
-  let revisionResponse = await phidToHg(phid);
+  const revisionResponse = await phidToHg(phid);
   if (revisionResponse.error) {
     console.error(revisionResponse.error);
     return null;

--- a/phabricator.js
+++ b/phabricator.js
@@ -8,6 +8,10 @@ let parentRevisionPromise;
 
 async function injectButton(block) {
   let path = block.querySelector('h1.differential-file-icon-header').textContent;
+  if (!isCoverageSupported(path)) {
+    return;
+  }
+
   let buttonDiv = block.querySelector('div.differential-changeset-buttons');
 
   function getLines() {

--- a/phabricator.js
+++ b/phabricator.js
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+let parentRevisionPromise;
+
+async function injectButton(block) {
+  let path = block.querySelector('h1.differential-file-icon-header').textContent;
+  let buttonDiv = block.querySelector('div.differential-changeset-buttons');
+
+  function getLines() {
+    return block.querySelectorAll('table.differential-diff tbody tr th:first-child');
+  }
+
+  let button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = 'Loading Code Coverage...';
+  button.disabled = true;
+  button.className = 'button button-grey';
+  buttonDiv.append(button);
+
+  let parentRevision = await parentRevisionPromise;
+  let data;
+  if (!parentRevision) {
+    data = null;
+  } else {
+    ({ data } = await fetchCoverage(parentRevision, path));
+  }
+
+  function applyOverlay(data) {
+    for (let line of getLines()) {
+      let lineNumber = parseInt(line.textContent);
+      if (isNaN(lineNumber)) {
+        continue;
+      }
+      if (!data.hasOwnProperty(lineNumber)) {
+        continue;
+      }
+
+      if (data[lineNumber] > 0) {
+        line.style.backgroundColor = 'greenyellow';
+      } else {
+        line.style.backgroundColor = 'tomato';
+      }
+    }
+  }
+
+  function removeOverlay() {
+    for (let line of getLines()) {
+      line.style.backgroundColor = '';
+    }
+  }
+
+  let enabled = false;
+  async function toggle() {
+    enabled = !enabled;
+
+    if (enabled) {
+      applyOverlay(data);
+    } else {
+      removeOverlay();
+    }
+  }
+
+  button.onclick = toggle;
+
+  // Enable or disable the code coverage button.
+  if (!data) {
+    button.textContent = 'No Code Coverage Data'
+  } else {
+    button.disabled = false;
+    button.textContent = 'Code Coverage'
+  }
+}
+
+async function fetchParentRevision() {
+  const revisionPHIDpattern = RegExp('/(PHID-DREV-[^/]*)/');
+  let href = document.querySelector('a.policy-link[data-sigil=workflow]').getAttribute('href');
+  let diffIdMatch = href.match(revisionPHIDpattern);
+  if (!diffIdMatch) {
+    console.error('diff id not found!');
+    return null;
+  }
+  let phid = diffIdMatch[1];
+
+  let revisionResponse = await phidToHg(phid);
+  if (revisionResponse.error) {
+    console.error(revisionResponse.error);
+    return null;
+  } else {
+    return revisionResponse.revision;
+  }
+}
+
+function inject() {
+  parentRevisionPromise = fetchParentRevision();
+  document.querySelectorAll('div[data-sigil=differential-changeset]').forEach(injectButton);
+}
+
+inject();


### PR DESCRIPTION
Closes https://github.com/mozilla/code-coverage-addon/issues/6

Still need to:

- add spinners
- clean up the code (right now, when you press a button, it waits for the async fetch to run)
- report errors in a more friendly way (right now, the button text changes, and it becomes disabled)
- remove the need for a Phabricator API key by hitting the APIs from the releng-services backend

How to see it in action:
- add your API key in `phab_api_key.js`
- visit https://phabricator.services.mozilla.com/D2187
- click on the button for `toolkit/components/search/nsSearchService.js`